### PR TITLE
Fix auto-created BQ dataset path to include project ID.

### DIFF
--- a/cli/lib/data_importer_test.py
+++ b/cli/lib/data_importer_test.py
@@ -60,6 +60,8 @@ class DataImporterTest(absltest.TestCase):
 
         self.timestamp_mock = self.enter_context(
             absltest.mock.patch.object(data_importer, 'Timestamp', autospec=True))
+        # set default value for attr created in __init__()
+        self.timestamp_mock.return_value.nanos = 0
 
         # Open is a native method so it can't be autospec'ed
         self.open_mock = self.enter_context(

--- a/cli/lib/framework_runner.py
+++ b/cli/lib/framework_runner.py
@@ -105,7 +105,7 @@ class FrameworkRunner:
     """Create the BigQuery dataset for the test"""
     # Construct a BigQuery client object.
     client = bigquery.Client()
-    dataset_id = f'vertex_ai_benchmarker_results_{self._target_qps}_qps_{str(uuid4())[:5]}'
+    dataset_id = f'{self._project_id}.vertex_ai_benchmarker_results_{self._target_qps}_qps_{str(uuid4())[:5]}'
 
     # Check if dataset exists. If not, create a new one.
     try:

--- a/cli/lib/framework_runner_test.py
+++ b/cli/lib/framework_runner_test.py
@@ -145,9 +145,9 @@ class FrameworkRunnerTest(absltest.TestCase):
 
     self.bq_mock.Client.assert_called_with()
     self.bq_client_mock.get_dataset.assert_called_with(
-        'vertex_ai_benchmarker_results_5_qps_d3d75')
+        'project.vertex_ai_benchmarker_results_5_qps_d3d75')
     self.bq_mock.Dataset.assert_called_with(
-        'vertex_ai_benchmarker_results_5_qps_d3d75')
+        'project.vertex_ai_benchmarker_results_5_qps_d3d75')
     self.bq_client_mock.create_dataset.assert_called_with(
         self.dataset_mock, timeout=30)
 
@@ -445,7 +445,7 @@ class FrameworkRunnerTest(absltest.TestCase):
         '--region=region --gcs_output_path=log-file-path '
         '--feature_query_file=/config/data/query_file.textproto '
         '--entity_file=gs://bucket/data/entity_file.txt --num_warmup_samples=5 '
-        '--bigquery_output_dataset=vertex_ai_benchmarker_results_5_qps_d3d75 project '
+        '--bigquery_output_dataset=project.vertex_ai_benchmarker_results_5_qps_d3d75 project '
         'data/query_file.textproto '
         'IyBwcm90by1maWxlOiBmZWF0dXJlc3RvcmVfb25saW5lX3NlcnZpY2UucHJvdG8KIyBwcm90by1tZXNzYWdlOiBSZXF1ZXN0cwoKcmVxdWVzdHNfcGVyX2ZlYXR1cmVzdG9yZTogewogIGZlYXR1cmVzdG9yZV9pZDogImJlbmNobWFya19mZWF0dXJlc3RvcmVfYWJjMTIzIgogIHJlcXVlc3RzOiB7CiAgICByZWFkX2ZlYXR1cmVfdmFsdWVzX3JlcXVlc3Q6IHsKICAgICAgZW50aXR5X3R5cGU6ICJodW1hbiIKICAgICAgZW50aXR5X2lkOiAiJHtFTlRJVFlfSUR9IgogICAgICBmZWF0dXJlX3NlbGVjdG9yOiB7CiAgICAgICAgaWRfbWF0Y2hlcjogewogICAgICAgICAgaWRzOiBbIioiXQogICAgICAgIH0KICAgICAgfQogICAgfQogIH0KfQo= '
         'example_entity_file.txt '
@@ -494,7 +494,7 @@ class FrameworkRunnerTest(absltest.TestCase):
         '--feature_query_file=/config/data/query_file.textproto '
         '--entity_file=/config/data/entity_file.txt '
         '--num_warmup_samples=5 '
-        '--bigquery_output_dataset=vertex_ai_benchmarker_results_7_qps_d3d75 '
+        '--bigquery_output_dataset=project.vertex_ai_benchmarker_results_7_qps_d3d75 '
         'projectfsloadtest-d3d75-job 1 image-url --target_qps=3 '
         '--num_threads=2 --sample_strategy=strategy '
         '--num_samples=10 --project_id=project --region=region '
@@ -502,7 +502,7 @@ class FrameworkRunnerTest(absltest.TestCase):
         '--feature_query_file=/config/data/query_file.textproto '
         '--entity_file=/config/data/entity_file.txt '
         '--num_warmup_samples=5 '
-        '--bigquery_output_dataset=vertex_ai_benchmarker_results_7_qps_d3d75 '
+        '--bigquery_output_dataset=project.vertex_ai_benchmarker_results_7_qps_d3d75 '
         'project',
         self.fdopen_text,
     )


### PR DESCRIPTION
What: Fully qualify the BQ path to include project ID.
Why: Fix usage for when target project is different than the default in the environment (set by gcloud/GCE).

Thanks for pointing out the tests. Fixed the two tests that were affected & fixed another set of tests that were failing.